### PR TITLE
Fix network driver in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,4 +64,4 @@ volumes:
 
 networks:
   auth-net:
-    driver: bridgecd
+    driver: bridge


### PR DESCRIPTION
## Summary
- correct the network driver for `auth-net` in `docker-compose.yaml`

## Testing
- `npm test`
- `docker-compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848473991f0832e93b02fd75f8ab198